### PR TITLE
Update libn_bagl_nanox.c to remove confusion

### DIFF
--- a/src/libn_bagl_nanox.c
+++ b/src/libn_bagl_nanox.c
@@ -365,7 +365,6 @@ UX_STEP_CB(
     {
         &C_icon_validate_14,
         "Accept",
-        "and send",
     });
 UX_STEP_CB(
     ux_confirm_sign_block_flow_8_step,


### PR DESCRIPTION
Some people have expressed confusion when confirming a receive block, as the UI says `Accept and send` although it's a RECEIVE/CHANGE block. 
To alleviate this confusion, I removed the `and send` part. 

To anyone that wants to contribute and make the `and send` part only applicable to SEND blocks, feel free to do it.