### PR TITLE
Replace outdated xrb_ address prefix with nano_ prefix

### DIFF
--- a/src/coins.c
+++ b/src/coins.c
@@ -15,7 +15,7 @@ REGISTER_COINS(
         .bip32Prefix = { HARDENED(44), HARDENED(165) },
         .addressPrimaryPrefix = "nano_",
         .addressSecondaryPrefix = "xrb_",
-        .addressDefaultPrefix = LIBN_SECONDARY_PREFIX,
+        .addressDefaultPrefix = LIBN_PRIMARY_PREFIX,
         .defaultUnit = "NANO",
         .defaultUnitScale = 30, // 1 Mnano = 10^30 raw
         #if defined(TARGET_BLUE)


### PR DESCRIPTION
No wallets that I know currently use xrb_ addresses and as a result, should not be the primary address prefix.
All transactions from wallets that support `nano_` addresses will use the `nano_` prefix, but transactions from wallets that still use `xrb_` will use `xrb_`. 