### PR TITLE
Fix Pin Validation on Sign Nonce

### DIFF
--- a/src/libn_apdu_sign_nonce.c
+++ b/src/libn_apdu_sign_nonce.c
@@ -53,7 +53,7 @@ uint16_t libn_apdu_sign_nonce(libn_apdu_response_t *resp) {
     os_memmove(req.keyPath, inPtr, MIN(readLen, sizeof(req.keyPath)));
     inPtr += readLen;
 
-    if (!os_global_pin_is_validated() != BOLOS_UX_OK) {
+    if (os_global_pin_is_validated() != BOLOS_UX_OK) {
         return LIBN_SW_SECURITY_STATUS_NOT_SATISFIED;
     }
 


### PR DESCRIPTION
There was an extra negate (!) on the validation, therefore always making that condition fail. This made the function unusable